### PR TITLE
avoid infinite loop in setPlayerFromCubes()

### DIFF
--- a/public/js/controler.js
+++ b/public/js/controler.js
@@ -939,9 +939,9 @@ function Controler( player ) {
 
         hasCollidedCube = false ;
 
-        setPlayerFromCubes();
+        setPlayerFromCubes(0);
 
-        function setPlayerFromCubes() {
+        function setPlayerFromCubes(count) {
 
             cubeCollision = atlas.collidePlayerCubes();
 
@@ -973,7 +973,7 @@ function Controler( player ) {
                     cubeCollision.point.z
                 );
 
-                setPlayerFromCubes();
+                if ( count < 7 ) setPlayerFromCubes( count + 1 );
 
             };
 


### PR DESCRIPTION
There were at least two places in your map where I managed to trigger this, so I went and "fixed" it. I figured there is no reason to keep the player bouncing between the cubes for 100s of iterations, it is better to go through the cube than become stuck in there.
```
InternalError: too much recursion 19 atlas.js:478:8
    checkStage https://makc.github.io/Edelweiss/js/atlas.js:478
    comparefn self-hosted:220
    InsertionSort self-hosted:3575
    MergeSort self-hosted:3631
    sort self-hosted:223
    checkStage https://makc.github.io/Edelweiss/js/atlas.js:476
    forEach self-hosted:235
    checkStage https://makc.github.io/Edelweiss/js/atlas.js:415
    collidePlayerCubes https://makc.github.io/Edelweiss/js/atlas.js:365
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:943
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
    setPlayerFromCubes https://makc.github.io/Edelweiss/js/controler.js:973
```