### PR TITLE
fix the glider🪂 and the gnome👞

### DIFF
--- a/public/js/AssetManager.js
+++ b/public/js/AssetManager.js
@@ -417,9 +417,20 @@ function AssetManager() {
 
 				obj.material = new THREE.MeshLambertMaterial({
 					map: obj.material.map,
-					side: THREE.FrontSide,
-					skinning: true
+					side: obj.material.side,
+					skinning: obj.material.skinning
 				});
+
+				// fix self-shadows on double-sided materials
+
+				obj.material.onBeforeCompile = function(stuff) {
+					var chunk = THREE.ShaderChunk.shadowmap_pars_fragment
+						.split ('z += shadowBias')
+						.join ('z += shadowBias - 0.001');
+					stuff.fragmentShader = stuff.fragmentShader
+						.split ('#include <shadowmap_pars_fragment>')
+						.join (chunk);
+				};
 
 				obj.castShadow = true ;
 				obj.receiveShadow = true ;

--- a/public/js/AssetManager.js
+++ b/public/js/AssetManager.js
@@ -13,8 +13,6 @@ function AssetManager() {
 	const SCALE_CHAR = 0.075 ;
 	const SCALE_EDELWEISS = 0.02 ;
 
-	const OFFSET_ALPINIST = new THREE.Vector3( 0, -0.5, 0 );
-	const OFFSET_LADY = new THREE.Vector3( 0, -0.5, 0 );
 	const OFFSET_EDELWEISS = new THREE.Vector3( 0, 0.1, 0 );
 
 	const particleMaterial = new THREE.MeshBasicMaterial({ color:0xffffff });
@@ -135,7 +133,7 @@ function AssetManager() {
 		createMultipleModels(
 			glb,
 			SCALE_ALPINIST,
-			OFFSET_ALPINIST,
+			null,
 			alpinists,
 			alpinistMixers,
 			alpinistIdles
@@ -148,7 +146,7 @@ function AssetManager() {
 		createMultipleModels(
 			glb,
 			SCALE_LADY,
-			OFFSET_LADY,
+			null,
 			ladies,
 			ladyMixers,
 			ladyIdles
@@ -334,13 +332,13 @@ function AssetManager() {
 
 	function createNewLady( logicCube ) {
 
-		setAssetAt( ladies, logicCube );
+		setAssetAt( ladies, logicCube, true, 0.45 );
 
 	};
 
 	function createNewAlpinist( logicCube ) {
 
-		setAssetAt( alpinists, logicCube );
+		setAssetAt( alpinists, logicCube, true, 0.6 );
 
 	};
 
@@ -357,7 +355,7 @@ function AssetManager() {
 	};
 
 	// Take the last free group from the right asset array, position it, and hide/show it.
-	function setAssetAt( assetArray, logicCube ) {
+	function setAssetAt( assetArray, logicCube, floor, bubbleOffset ) {
 
 		let pos = logicCube.position ;
 		let tag = logicCube.tag ;
@@ -368,10 +366,22 @@ function AssetManager() {
 
 				asset.position.copy( pos );
 
+				if ( floor ) {
+					asset.position.y = Math.floor( asset.position.y );
+
+					// patch the cube position itself to get the
+					// exclamation mark sign positioned properly
+
+					pos.y = Math.floor( pos.y ) + bubbleOffset;
+				}
+
 				asset.userData.isSet = true ;
 				asset.userData.tag = tag ;
 				asset.userData.graph = getGraphFromTag( tag );
-				asset.userData.initPos = new THREE.Vector3().copy( pos );
+
+				// anchor for bonus floating animation
+
+				asset.userData.initPos = asset.position.clone();
 
 				setGroupVisibility( asset );
 


### PR DESCRIPTION
While poking around the shadows I finally found out why did you have to make the glider one-sided and dig your gnomes knee-deep into the ground :) Well, no more - this hack applies extra shadow bias on the characters to avoid shadow issues:
![Screen Shot 2020-04-09 at 20 51 09 ](https://user-images.githubusercontent.com/242577/78930345-3889c680-7aa4-11ea-9c93-1dd5db281f57.png)
![Screen Shot 2020-04-09 at 20 51 29 ](https://user-images.githubusercontent.com/242577/78930352-3c1d4d80-7aa4-11ea-8717-384128a863b7.png)
(I keep calling them gnomes, but they are the tallest characters in the game lol)